### PR TITLE
Apply fix

### DIFF
--- a/frontend/src/components/common/MessageView.vue
+++ b/frontend/src/components/common/MessageView.vue
@@ -99,6 +99,14 @@
                 <font-awesome-icon icon="flag" class="action-icon" />
                 {{ t('report.report') }}
               </button>
+              <button
+                v-if="props.canDeleteAnyMessage"
+                class="dropdown-action delete-action"
+                @click="handleMessageDelete"
+              >
+                <font-awesome-icon icon="trash" class="action-icon" />
+                {{ t('common.delete') }}
+              </button>
             </div>
           </transition>
         </div>
@@ -199,6 +207,10 @@ const props = defineProps({
     default: null
   },
   isHost: {
+    type: Boolean,
+    default: false
+  },
+  canDeleteAnyMessage: {
     type: Boolean,
     default: false
   }

--- a/frontend/src/views/RoomDetail.vue
+++ b/frontend/src/views/RoomDetail.vue
@@ -42,7 +42,7 @@
             <label for="invite-role">{{ t('room.roleOptional') }}</label>
             <select id="invite-role" v-model="inviteRoleId" class="form-select">
               <option :value="null">{{ t('room.noRole') }}</option>
-              <option v-for="role in roomRoles" :key="role.id" :value="role.id">{{ role.name }}</option>
+              <option v-for="role in assignableRoles" :key="role.id" :value="role.id">{{ role.name }}</option>
             </select>
           </div>
           <div class="modal-actions">
@@ -64,7 +64,7 @@
           <label for="select-role">{{ t('room.selectRole') }}</label>
           <select id="select-role" v-model="selectedRoleId" class="form-select">
             <option :value="null" disabled>{{ t('room.selectARolePlaceholder') }}</option>
-            <option v-for="role in roomRoles" :key="role.id" :value="role.id">{{ role.name }}</option>
+            <option v-for="role in assignableRoles" :key="role.id" :value="role.id">{{ role.name }}</option>
           </select>
         </div>
         <p v-if="roleChangeError" class="modal-error">{{ roleChangeError }}</p>
@@ -278,6 +278,7 @@
               :message="message"
               :current-user-id="authStore.user?.id"
               :is-host="message.author?.id === room?.host?.id"
+              :can-delete-any-message="canDeleteAnyMessage"
               @delete-message="handleMessageDelete"
               @update-message="handleMessageUpdate"
               @report-message="handleReportMessage"
@@ -371,7 +372,7 @@ import ConfirmationModal from '@/components/layout/ConfirmationModal.vue';
 import RoleManager from '@/components/common/RoleManager.vue';
 import ReportModal from '@/components/common/ReportModal.vue';
 import { ReportTargetType } from '@/types';
-import type { Room, Participant, UUID } from '@/types';
+import type { Room, Participant, UUID, Role } from '@/types';
 
 const MESSAGE_WARNING_THRESHOLD = Math.floor(MESSAGE_LIMITS.body * 0.9);
 
@@ -535,6 +536,24 @@ const { changeParticipantRole: changeRoleMutation, loading: changeRoleLoading } 
 const { removeParticipant: removeParticipantMutation } = useRemoveParticipant();
 const { sendInvite: sendInviteMutation, loading: sendInviteLoading } = useSendInvite();
 const { roles: roomRoles } = useRoomRoles(roomId);
+
+const myRole = computed(() => {
+  const user = authStore.user;
+  if (!user || !room.value) return null;
+  const myParticipant = room.value.participants.find((p: Participant) => p.user.id === user.id);
+  if (!myParticipant?.role?.id) return null;
+  return roomRoles.value.find((r: Role) => r.id === myParticipant.role.id) ?? null;
+});
+
+const assignableRoles = computed(() => {
+  if (!myRole.value) return [];
+  return roomRoles.value.filter((r: Role) => r.priority < myRole.value!.priority);
+});
+
+const canDeleteAnyMessage = computed(() => {
+  if (isHost.value) return true;
+  return myRole.value?.permissions?.some((p: { code: string }) => p.code === 'room.delete_message') ?? false;
+});
 
 // Invite modal state
 const showInviteModal = ref(false);


### PR DESCRIPTION
This pr tries to fix multiple role assignment issues:
- Users sees roles in the list (invites creation or role assignment) even if the user doesn't permissions to assigne the specific role (priority too low)
- Role with a permission MESSAGE_DELETE (or any other permission) doesn't actually grant it from a ui standpoint. The user will still have no button to perform the action his role is capable of.